### PR TITLE
Fixed a problem handling 'arrow()' and 'unit()' functions needed for …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,8 @@ Imports:
   ggplot2,
   network,
   scales,
-  sna
+  sna,
+  grid
 Suggests:
   igraph,
   intergraph,

--- a/R/ggnet.R
+++ b/R/ggnet.R
@@ -204,9 +204,11 @@ ggnet <- function(
   ...
 ){
 
+
+
   # -- packages ----------------------------------------------------------------
 
-  require_pkgs(c("network", "sna", "scales"))
+  require_pkgs(c("network", "sna", "scales", "grid"))
 
   # -- deprecations ------------------------------------------------------------
 
@@ -377,24 +379,29 @@ ggnet <- function(
 
   x = weight.method
 
-  if (length(x) == 1 && x %in% c("indegree", "outdegree", "degree", "freeman")) {
+  if (length(x) == 1) {
+     if (x %in% c("indegree", "outdegree", "degree", "freeman")) {
 
-    # prevent namespace conflict with igraph
-    if ("package:igraph" %in% search()) {
+        # prevent namespace conflict with igraph
+        if ("package:igraph" %in% search()) {
+           y = ifelse(is_dir == "digraph", "directed", "undirected")
+           z = c("indegree" = "in", "outdegree" = "out", "degree" = "all", "freeman" = "all")[ x ]
+           data$weight = igraph::degree(igraph::graph.adjacency(as.matrix(net), mode = y), mode = z)
 
-      y = ifelse(is_dir == "digraph", "directed", "undirected")
-      z = c("indegree" = "in", "outdegree" = "out", "degree" = "all", "freeman" = "all")[ x ]
-      data$weight = igraph::degree(igraph::graph.adjacency(as.matrix(net), mode = y), mode = z)
-
-    } else {
-      data$weight = sna::degree(net, gmode = is_dir, cmode = ifelse(x == "degree", "freeman", x))
-    }
+        } else {
+           data$weight = sna::degree(net, gmode = is_dir, cmode = ifelse(x == "degree", "freeman", x))
+        }
+     } else if (x %in% v_attr) {
+        data$weight = get_v(net, x)
+     } else if (x != "none" && !(x %in% v_attr)) {
+        stop("incorrect weight.method value")
+     }
 
   } else if (length(x) > 1 && length(x) == n_nodes) {
-    data$weight = x
-  } else if (length(x) == 1 && x %in% v_attr) {
-    data$weight = get_v(net, x)
+     data$weight = x
   }
+
+
 
   if (!is.null(data$weight) && !is.numeric(data$weight)) {
     stop("incorrect weight.method value")
@@ -615,9 +622,9 @@ ggnet <- function(
         alpha  = segment.alpha,
         size   = segment.size,
         color  = segment.color,
-        arrow  = arrow(
+        arrow  = grid::arrow(
           type   = arrow.type,
-          length = unit(arrow.size, "pt")
+          length = grid::unit(arrow.size, "pt")
         )
       )
 

--- a/R/ggnet2.R
+++ b/R/ggnet2.R
@@ -305,7 +305,7 @@ ggnet2 <- function(
 
   # -- packages ----------------------------------------------------------------
 
-  require_pkgs(c("network", "sna", "scales"))
+  require_pkgs(c("network", "sna", "scales", "grid"))
 
   # -- conversion to network class ---------------------------------------------
 
@@ -883,9 +883,9 @@ ggnet2 <- function(
         color  = edge.color,
         alpha  = edge.alpha,
         lty    = edge.lty,
-        arrow  = arrow(
+        arrow  = grid::arrow(
           type   = arrow.type,
-          length = unit(arrow.size, "pt")
+          length = grid::unit(arrow.size, "pt")
         )
       )
 

--- a/tests/testthat/test-examples.R
+++ b/tests/testthat/test-examples.R
@@ -1,0 +1,7 @@
+library(ggnet)
+library(testthat)
+
+context("test all examples in ggnet and ggnet2 documentation")
+
+
+test_examples()

--- a/tests/testthat/test-ggnet.R
+++ b/tests/testthat/test-ggnet.R
@@ -1,56 +1,26 @@
+library(ggnet)
+library(testthat)
 
 context("ggnet")
 
-if ("package:igraph" %in% search()) {
-  detach("package:igraph")
-}
 
-require(network      , quietly = TRUE) # network objects
-require(sna          , quietly = TRUE) # placement and centrality
+require(network, quietly = TRUE) # network object manipulation
+x                     <- 10
+ndyads                <- x * (x - 1)
+density               <- x / ndyads
+m                     <- matrix(0, nrow = x, ncol = x)
+dimnames(m)           <- list(letters[ 1:x ], letters[ 1:x ])
+m[ row(m) != col(m) ] <- runif(ndyads) < density
+n                     <- network::network(m, directed = FALSE)
+xy                    <- sna::gplot.layout.circle(m)
+n %v% "lon"           <- xy[, 1]
+n %v% "lat"           <- xy[, 2]
 
-require(ggplot2      , quietly = TRUE) # grammar of graphics
-require(grid         , quietly = TRUE) # arrows
-require(scales       , quietly = TRUE) # sizing
 
-require(intergraph   , quietly = TRUE) # test igraph conversion
 
-test_that("examples", {
 
-  ### --- start: documented examples
-
-  # random adjacency matrix
-  x           <- 10
-  ndyads      <- x * (x - 1)
-  density     <- x / ndyads
-  m           <- matrix(0, nrow = x, ncol = x)
-  dimnames(m) <- list(letters[ 1:x ], letters[ 1:x ])
-  m[ row(m) != col(m) ] <- runif(ndyads) < density
-  m
-
-  # random undirected network
-  n <- network::network(m, directed = FALSE)
-  n
-
-  ggnet(n, label = TRUE, alpha = 1, color = "white", segment.color = "black")
-
-  # random groups
-  g <- sample(letters[ 1:3 ], 10, replace = TRUE)
-
-  # color palette
-  p <- c("a" = "steelblue", "b" = "forestgreen", "c" = "tomato")
-
-  p = ggnet(n, node.group = g, node.color = p, label = TRUE, color = "white")
-  expect_equal(length(p$layers), 3)
-  expect_true(!is.null(p$mapping$colour))
-
-  ### --- end: documented examples
-
-  ### --- test deprecations
-
+test_that("test deprecations",{
   # test mode = "geo"
-  xy = gplot.layout.circle(n)
-  n %v% "lon" = xy[, 1]
-  n %v% "lat" = xy[, 2]
   expect_warning(ggnet(n, mode = "geo"), "deprecated")
 
   # test names = c(x, y)
@@ -92,10 +62,13 @@ test_that("examples", {
 
   # test weight.cut
   n %v% "weights" = 1:10
-  ggnet(n, weight.method = "weights", weight.cut = TRUE)
+  suppressWarnings(ggnet(n, weight.method = "weights", weight.cut = TRUE))
+})
 
-  ### --- test errors in set_node
 
+
+
+test_that("test errors in set_node", {
   expect_error(ggnet(n, group = NA), "incorrect")
   expect_error(ggnet(n, group = 1:3), "incorrect")
   expect_error(ggnet(n, label = TRUE, label.size = -10:-1), "incorrect")
@@ -113,35 +86,45 @@ test_that("examples", {
   n %e% "weights" = sample(1:2, network.edgecount(n), replace = TRUE)
   ggnet(n, segment.label = "weights")
   ggnet(n, segment.label = "a")
+})
 
-  ### --- test mode = c(x, y)
 
+
+test_that("test mode = c(x, y)", {
   ggnet(n, mode = matrix(1, ncol = 2, nrow = 10))
   ggnet(n, mode = c("lon", "lat"))
   expect_error(ggnet(n, mode = c("xx", "yy")), "not found")
   n %v% "abc" = "abc"
   expect_error(ggnet(n, mode = c("abc", "abc")), "not numeric")
   expect_error(ggnet(n, mode = matrix(1, ncol = 2, nrow = 9)), "coordinates length")
+})
 
-  ### --- test arrow.size
 
+
+test_that("test arrow.size", {
   expect_error(ggnet(n, arrow.size = -1), "incorrect arrow.size")
   expect_warning(ggnet(n, arrow.size = 1), "arrow.size ignored")
+})
 
-  ### --- test arrow.gap
 
-  expect_error(ggnet(n, arrow.size = 12, arrow.gap = -1), "incorrect arrow.gap")
+
+test_that("test arrow.gap", {
+  expect_error(suppressWarnings(ggnet(n, arrow.size = 12, arrow.gap = -1)), "incorrect arrow.gap")
   expect_warning(ggnet(n, arrow.size = 12, arrow.gap = 0.1), "arrow.gap ignored")
 
   m <- network::network(m, directed = TRUE)
   ggnet(m, arrow.size = 12, arrow.gap = 0.05)
+})
 
-  ### --- test degree centrality
 
+
+test_that("test degree centrality", {
   ggnet(n, weight = "degree")
+})
 
-  ### --- test weight.min, weight.max and weight.cut
 
+
+test_that("test weight.min, weight.max and weight.cut", {
   # test weight.min
   expect_error(ggnet(n, weight = "degree", weight.min = -1), "incorrect weight.min")
   expect_message(ggnet(n, weight = "degree", weight.min = 1), "weight.min removed")
@@ -158,32 +141,38 @@ test_that("examples", {
   expect_error(ggnet(n, weight.cut = "a"), "incorrect weight.cut")
   expect_warning(ggnet(n, weight.cut = 3), "weight.cut ignored")
   ggnet(n, weight = "degree", weight.cut = 3)
+})
 
-  ### --- test node.group and node.color
 
+
+test_that("test node.group and node.color", {
   expect_warning(ggnet(n, group = 1:10, node.color = "blue"), "unequal length")
+})
 
-  ### --- test node labels and label sizes
 
+
+test_that("test node labels and label sizes", {
   ggnet(n, label = letters[ 1:10 ], color = "white")
   ggnet(n, label = "abc", color = "white", label.size = 4, size = 12)
   expect_error(ggnet(n, label = letters[ 1:10 ], label.size = "abc"), "incorrect label.size")
+})
 
-  ### --- test node placement
 
+
+
+test_that("node placement, label.trim, layout.exp, bipartite functionality", {
   expect_error(ggnet(n, mode = "xyz"), "unsupported")
   expect_error(ggnet(n, mode = letters[1:3]), "incorrect mode")
 
-  ### --- test label.trim
+
   expect_error(ggnet(n, label = TRUE, label.trim = "xyz"), "incorrect label.trim")
   ggnet(n, label = TRUE, color = "white", label.trim = 1)
   ggnet(n, label = TRUE, color = "white", label.trim = toupper)
 
-  ### --- test layout.exp
+
   expect_error(ggnet(n, layout.exp = "xyz"))
   ggnet(n, layout.exp = 0.1)
 
-  ### --- test bipartite functionality
 
   # weighted adjacency matrix
   bip = data.frame(event1 = c(1, 2, 1, 0),
@@ -199,19 +188,22 @@ test_that("examples", {
 
   # test bipartite mode
   ggnet(bip, group = "mode")
+})
 
-  ### --- test network coercion
 
+
+test_that("test network coercion", {
   expect_warning(ggnet(network(matrix(1, nrow = 2, ncol = 2), loops = TRUE)), "self-loops")
-
   expect_error(ggnet(1:2), "network object")
   expect_error(ggnet(network(data.frame(1:2, 3:4), hyper = TRUE)), "hyper graphs")
   expect_error(ggnet(network(data.frame(1:2, 3:4), multiple = TRUE)), "multiplex graphs")
+})
 
-  ### --- test igraph functionality
 
+
+test_that("test igraph functionality", {
   # test igraph conversion
-  p = ggnet(asIgraph(n))
+  p = ggnet(intergraph::asIgraph(n))
   expect_null(p$guides$colour)
   expect_equal(length(p$layers), 2)
 
@@ -220,5 +212,4 @@ test_that("examples", {
   ggnet(n, weight = "degree")
 
   expect_true(TRUE)
-
 })


### PR DESCRIPTION
…plotting, which closes #11. In particular, the grid package was added to require_pkgs and adding grid:: prefix to arrow() and unit() calls (to eliminate devtools::check() note 'no visible global function definition') in 'ggnet()' and 'ggnet2()'. Re-organization of tests so that they now would not fail to reproduce the error in issue #11 (if it had not been fixed). Checking the package with devtools::check() now results in Status: OK (no error, warning or note).
